### PR TITLE
Corrections after initial run

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Here is an example of using the MST model:
 
 ```python
 import pandas as pd
-from dpmm.models import MST
+from dpmm.models import MSTGM as MST
 
 # Load your data
 data = pd.read_csv('your_data.csv')

--- a/src/dpmm/pipelines/__init__.py
+++ b/src/dpmm/pipelines/__init__.py
@@ -3,4 +3,4 @@ from dpmm.pipelines.mst import MSTPipeline
 from dpmm.pipelines.priv_bayes import PrivBayesPipeline
 
 PIPELINES = [AIMPipeline, MSTPipeline, PrivBayesPipeline]
-PIPELINE_DICT = {PIPE.model.name: PIPE for PIPE in PipelineS}
+PIPELINE_DICT = {PIPE.model.name: PIPE for PIPE in PIPELINES}


### PR DESCRIPTION
Signed-off-by: SundareshSankaran <Sundaresh.Sankaran@gmail.com>

1. __init__.py in pipelines seemed to contain typo not resolving var
2. MST, AIM and PrivBayes have a GM suffix in models/__init__.py.  README example assumed MST.  I assume we keep GM suffix.  Current change is halfway, based on whether you want a MST() or a MSTGM() reference in the snippet.