### PR TITLE
Enclosed all file openning calls with context managers

### DIFF
--- a/src/dpmm/models/base/mbi/dataset.py
+++ b/src/dpmm/models/base/mbi/dataset.py
@@ -43,7 +43,8 @@ class Dataset:
         :param domain: path to json file encoding the domain information
         """
         df = pd.read_csv(path)
-        config = json.load(open(domain))
+        with open(domain) as f:
+            config = json.load(f)
         domain = Domain(config.keys(), config.values())
         return Dataset(df, domain)
 

--- a/src/dpmm/models/base/mbi/graphical_model.py
+++ b/src/dpmm/models/base/mbi/graphical_model.py
@@ -54,11 +54,13 @@ class GraphicalModel:
         return self._prng
 
     def save(self, path):
-        pickle.dump(self, open(path, "wb"))
+        with open(path, "wb") as f:
+            pickle.dump(self, f)
 
     @classmethod
     def load(cls, path):
-        return pickle.load(open(path, "rb"))
+        with open(path, "rb") as f:
+            return pickle.load(f)
 
     def project(self, attrs):
         """Project the distribution onto a subset of attributes.


### PR DESCRIPTION
Solves #7 .

I saerched for all calls to "open(", which are used in the project to load pickle or json files. There are 5 calls in total. 3 were fixed, the other 2 were enclosed already. The other disk operations use joblib, so they don't need to be enclosed.