### PR TITLE
Fix mirror descent step size behavior.

### DIFF
--- a/src/dpmm/models/base/mbi/inference.py
+++ b/src/dpmm/models/base/mbi/inference.py
@@ -270,18 +270,22 @@ class FactoredInference:
         nols = stepsize is not None
         if np.isscalar(stepsize):
             alpha = float(stepsize)
-            stepsize = alpha
+
+            def stepsize(_):
+                return alpha
+
         if stepsize is None:
             alpha = 1.0 / self.model.total**2
-            stepsize = 2.0 * alpha
 
+            def stepsize(_):
+                return 2.0 * alpha
         for t in range(1, self.iters + 1):
             if callback is not None:
                 callback(mu)
             omega, nu = theta, mu
             curr_loss, d_l = ans
             # print('Gradient Norm', np.sqrt(d_l.dot(d_l)))
-            alpha = stepsize
+            alpha = stepsize(t)
             for _ in range(25):
                 theta = omega - alpha * d_l
                 mu = model.belief_propagation(theta)


### PR DESCRIPTION
## Summary

This PR restores the original step-size scheduling behavior in `FactoredInference.mirror_descent`.

While investigating a utility regression, I used `git bisect` and identified commit `bdfcf015` as the first bad commit. The regression was further isolated to the handling of `stepsize` in `src/dpmm/models/base/mbi/inference.py`, specifically in `mirror_descent`.

The refactoring in `bdfcf015` replaced the callable step-size schedule with a scalar value, changing the behavior of the optimization routine. This PR restores the original callable behavior.

## Validation

The fix was validated by rerunning the benchmark that originally exposed the regression (see GitHub issue #27). After applying this change, the expected utility was restored.